### PR TITLE
Rework interval calculation to make more sense

### DIFF
--- a/plot_likert/plot_likert.py
+++ b/plot_likert/plot_likert.py
@@ -82,8 +82,10 @@ def plot_counts(
 
     # Compute and show x labels
     if plot_percentage:
-        # Percentage values are based on the interval, e.g. [0, 10, 20] if percent_interval == 10
-        # Try to find the highest percentage value needed
+        if (ax.xaxis.get_tick_space() < max_width / percent_interval):
+            warn(
+                "Not enough ticks for given percentage interval. Consider choosing a higher percentage interval."
+            )
         intervals = (max_width // percent_interval) + 2
         labels = np.arange(0, intervals * percent_interval, percent_interval)
         print(labels)
@@ -103,7 +105,8 @@ def plot_counts(
             warn(
                 "Not enough ticks for given value interval. Consider choosing a higher value interval."
             )
-        labels = np.arange(0, max_width + value_interval, value_interval)
+        intervals = (max_width // value_interval) + 2
+        labels = np.arange(0, intervals * value_interval, value_interval)
         print(labels)
         right_values = center + labels
         left_values = center - labels

--- a/plot_likert/plot_likert.py
+++ b/plot_likert/plot_likert.py
@@ -195,6 +195,8 @@ def plot_likert(
     plot_scale: Scale,
     plot_percentage: bool = False,
     format_scale: Scale = None,
+    percent_interval = 10,
+    value_interval = 1,
     colors: colors.Colors = colors.default,
     label_max_width: int = 30,
     drop_zeros: bool = False,
@@ -218,7 +220,7 @@ def plot_likert(
     else:
         counts = likert_counts(df_fixed, format_scale, label_max_width, drop_zeros)
 
-    plot_counts(counts, plot_scale, plot_percentage, colors, figsize=figsize)
+    plot_counts(counts=counts, scale=plot_scale, plot_percentage=plot_percentage, percent_interval=percent_interval, colors=colors, figsize=figsize)
 
 
 def raw_scale(df: pd.DataFrame) -> pd.DataFrame:

--- a/plot_likert/plot_likert.py
+++ b/plot_likert/plot_likert.py
@@ -98,8 +98,10 @@ def plot_counts(
         
     
     # Generate xlabels, xvalues
-    ticks_needed = (max_width // interval) + 1
-    labels = np.arange(0, (ticks_needed+1) * interval, interval) # arange does not include the stop value, but we want it to
+    ticks_needed = (max_width // interval) + 1 # 'ceiling division'
+    # Arg 2 is +1 because otherwise the last element would be below max_width 
+    # as arange does not include the stop value in the array
+    labels = np.arange(0, (ticks_needed+1) * interval, interval) 
     right_values = center + labels
     left_values = center - labels
     xlabels = np.concatenate([labels, labels])
@@ -216,7 +218,10 @@ def plot_likert(
     else:
         counts = likert_counts(df_fixed, format_scale, label_max_width, drop_zeros)
 
-    plot_counts(counts=counts, scale=plot_scale, plot_percentage=plot_percentage, interval=interval, colors=colors, figsize=figsize)
+    plot_counts(
+        counts=counts, scale=plot_scale, plot_percentage=plot_percentage, 
+        interval=interval, colors=colors, figsize=figsize
+    )
 
 
 def raw_scale(df: pd.DataFrame) -> pd.DataFrame:

--- a/plot_likert/plot_likert.py
+++ b/plot_likert/plot_likert.py
@@ -91,11 +91,15 @@ def plot_counts(
         left_values = center - labels
         xlabels = np.concatenate([labels, labels])
         xvalues = np.concatenate([left_values, right_values])
+
+        # Remove duplicate zeroes
+        xlabels = xlabels[1:]
+        xvalues = xvalues[1:] 
+
         xlabels = [str(int(label)) + "%" for label in xlabels]
         ax.set_xlabel("Percentage of Responses")
     else:
-        num_ticks = ax.xaxis.get_tick_space()
-        if (num_ticks < max_width / value_interval):
+        if (ax.xaxis.get_tick_space() < max_width / value_interval):
             warn(
                 "Not enough ticks for given value interval. Consider choosing a higher value interval."
             )
@@ -105,6 +109,11 @@ def plot_counts(
         left_values = center - labels
         xlabels = np.concatenate([labels, labels])
         xvalues = np.concatenate([left_values, right_values])
+
+        # Remove duplicate zeroes
+        xlabels = xlabels[1:]
+        xvalues = xvalues[1:] 
+
         ax.set_xlabel("Number of Responses")
 
     ax.set_xticks(xvalues)
@@ -114,8 +123,6 @@ def plot_counts(
     plt.legend(bbox_to_anchor=(1.05, 1))
 
     return ax
-
-
 def likert_counts(
     df: pd.DataFrame, scale: Scale, label_max_width=30, drop_zeros=False
 ) -> pd.DataFrame:


### PR DESCRIPTION
As referenced in #4, with responses that lean particularly in one direction it was possible to have a plot with labels like 102%:

![issue](https://user-images.githubusercontent.com/5047192/86876129-e7f22b80-c0db-11ea-8713-db76bdab5924.png)

I'm not a data scientist, but I felt that the highest label should be 100%, and this small patch should hopefully make that the case. If percentage mode is on, the program now just goes through `right_labels` and `left_labels` after they were generated and caps any values at 100. Hopefully this isn't too hacky of a solution; it seems to work but I'm not sure if it'd be better to rework the underlying code that was producing >100 percentages.

I don't know how you do your versioning, but I just bumped it to 0.2.5. Let me know if you'd rather it was 0.2.4a, given the small nature of the change.