### PR TITLE
Stop double-writing the xtick at 0

### DIFF
--- a/plot_likert/plot_likert.py
+++ b/plot_likert/plot_likert.py
@@ -84,7 +84,7 @@ def plot_counts(
         interval = xtick_interval
 
     right_edge = max_width - center
-    right_labels = np.arange(0, right_edge + interval, interval)
+    right_labels = np.arange(interval, right_edge + interval, interval)
     right_values = center + right_labels
     left_labels = np.arange(0, center + 1, interval)
     left_values = center - left_labels


### PR DESCRIPTION
Another little bugfix: the current code results in two overlapping xticks at 0 which looks slightly odd. 