### PR TITLE
Remove "legend" entry from legend

### DIFF
--- a/plot_likert/plot_likert.py
+++ b/plot_likert/plot_likert.py
@@ -61,8 +61,8 @@ def plot_counts(
 
     padding_values = (middles - center).abs()
     padded_counts = pd.concat([padding_values, counts], axis=1)
-    # hack to "hide" the label for the padding
-    padded_counts = padded_counts.rename({0: "Legend"}, axis=1)
+    # Hide the padding row: pandas ignores data prefixed by "_"
+    padded_counts = padded_counts.rename({0: "_padding_row"}, axis=1)
 
     # Reverse rows to keep the questions in order
     # (Otherwise, the plot function shows the last one at the top.)

--- a/plot_likert/plot_likert.py
+++ b/plot_likert/plot_likert.py
@@ -61,8 +61,8 @@ def plot_counts(
 
     padding_values = (middles - center).abs()
     padded_counts = pd.concat([padding_values, counts], axis=1)
-    # Hide the padding row: matplotlib ignores data prefixed by "_"
-    padded_counts = padded_counts.rename({0: "_padding_row"}, axis=1)
+    # Hide the padding row from the legend
+    padded_counts = padded_counts.rename({0: ""}, axis=1)
 
     # Reverse rows to keep the questions in order
     # (Otherwise, the plot function shows the last one at the top.)

--- a/plot_likert/plot_likert.py
+++ b/plot_likert/plot_likert.py
@@ -61,7 +61,7 @@ def plot_counts(
 
     padding_values = (middles - center).abs()
     padded_counts = pd.concat([padding_values, counts], axis=1)
-    # Hide the padding row: pandas ignores data prefixed by "_"
+    # Hide the padding row: matplotlib ignores data prefixed by "_"
     padded_counts = padded_counts.rename({0: "_padding_row"}, axis=1)
 
     # Reverse rows to keep the questions in order


### PR DESCRIPTION
Hide the "legend" padding box by marking it with a `_` for matplotlib to ignore (see http://blog.rtwilson.com/easily-hiding-items-from-the-legend-in-matplotlib/)

PS hope you don't mind all these little changes!