### PR TITLE
Plot correct percentages when using plot_counts

### DIFF
--- a/plot_likert/plot_likert.py
+++ b/plot_likert/plot_likert.py
@@ -52,6 +52,10 @@ def plot_counts(
     # Pad each row/question from the left, so that they're centered around the middle (Neutral) response
     scale_middle = len(scale) // 2
 
+    # scales labels to correct percentages
+    if plot_percentage:
+        counts = likert_percentages(counts, scale, from_count=True)
+
     if scale_middle == len(scale) / 2:
         middles = counts.iloc[:, 0:scale_middle].sum(axis=1)
     else:
@@ -154,14 +158,19 @@ def likert_counts(
 
 
 def likert_percentages(
-    df: pd.DataFrame, scale: Scale, width=30, zero=False
+    df: pd.DataFrame, scale: Scale, width=30, zero=False, counted=False
 ) -> pd.DataFrame:
     """
     Given a dataframe of Likert-style responses, returns a new one
     reporting the percentage of respondents that chose each response.
     Percentages are rounded to integers.
     """
-    counts = likert_counts(df, scale, width, zero)
+
+    # checks if df is already counted
+    if not counted:
+        counts = likert_counts(df, scale, width, zero)
+    else:
+        counts = df
 
     # Warn if the rows have different counts
     # If they do, the percentages shouldn't be compared.


### PR DESCRIPTION
### Issue
When using _plot_count_ to plot a graph, _plot_percentages_ seemed to only just add a percentage sign on to the end of the number of respondents rather than convert the number of responses to percentages.

### Soloution
Modified the _likert_percentage_ function to be able to accept dataframes which are already counted and then added a conditional in _plot_count_ to modify the dataframe accordingly if _plot_percentages=True_.