### PR TITLE
Improve handling of percentages for plot_counts

### DIFF
--- a/plot_likert/plot_likert.py
+++ b/plot_likert/plot_likert.py
@@ -44,10 +44,11 @@ class PlotLikertError(ValueError):
 def plot_counts(
     counts: pd.DataFrame,
     scale: Scale,
-    plot_percentage: bool = False,
+    plot_percentage: typing.Optional[bool] = None,
     colors: colors.Colors = colors.default,
     figsize=None,
     xtick_interval: typing.Optional[int] = None,
+    counts_are_percentages: bool = False,
 ) -> matplotlib.axes.Axes:
     """
     Plot the given counts of Likert responses.
@@ -60,8 +61,11 @@ def plot_counts(
         Its columns represent the total counts in each category, while each row is a different question.
     scale : list of str
         The scale used for the plot: an ordered list of strings for each of the answer options.
-    plot_percentage : bool
+    plot_percentage : bool, optional
+        DEPRECATED: use `counts_are_percentages` instead.
+        That parameter is named more descriptively but retains this one's behavior:
         If true, the counts are assumed to be percentages and % marks will be added to the x-axis labels.
+        If both `plot_percentage` and `counts_are_percentages` are specified, the former overrides the latter.
     colors : list of str
         A list of colors in hex string or RGB tuples to use for plotting.
         Attention: if your colormap doesn't work right try appending transparent ("#ffffff00") in the first place.
@@ -69,6 +73,8 @@ def plot_counts(
         A tuple (width, heigth) that controls size of the final figure - similarly to matplotlib
     xtick_interval : int, optional
         Controls the interval between x-axis ticks.
+    counts_are_percentages: bool = False,
+        If true, the counts are assumed to be percentages and % marks will be added to the x-axis labels.
 
     Returns
     -------
@@ -79,6 +85,13 @@ def plot_counts(
     --------
     plot_likert : aggregate raw responses then plot them. Most often, you'll want to use that function instead of calling this one directly.
     """
+    if plot_percentage is not None:
+        warn(
+            "parameter `plot_percentage` for `plot_likert.likert_counts` is deprecated, use `counts_are_percentages` instead",
+            FutureWarning,
+        )
+        counts_are_percentages = plot_percentage
+
     # Pad each row/question from the left, so that they're centered around the middle (Neutral) response
     scale_middle = len(scale) // 2
 
@@ -135,12 +148,12 @@ def plot_counts(
         total_max = counts.sum(axis="columns").max()
         xlabels = ["" if label > total_max else label for label in xlabels]
 
-    if plot_percentage:
+    if counts_are_percentages:
         xlabels = [str(label) + "%" if label != "" else "" for label in xlabels]
 
     ax.set_xticks(xvalues)
     ax.set_xticklabels(xlabels)
-    if plot_percentage is True:
+    if counts_are_percentages is True:
         ax.set_xlabel("Percentage of Responses")
     else:
         ax.set_xlabel("Number of Responses")

--- a/plot_likert/plot_likert.py
+++ b/plot_likert/plot_likert.py
@@ -49,7 +49,6 @@ def plot_counts(
     figsize=None,
     xtick_interval: typing.Optional[int] = None,
     compute_percentages: bool = False,
-    counts_are_percentages: bool = False,
 ) -> matplotlib.axes.Axes:
     """
     Plot the given counts of Likert responses.
@@ -63,10 +62,8 @@ def plot_counts(
     scale : list of str
         The scale used for the plot: an ordered list of strings for each of the answer options.
     plot_percentage : bool, optional
-        DEPRECATED: use `counts_are_percentages` instead.
-        That parameter is named more descriptively but retains this one's behavior:
+        DEPRECATED: use `compute_percentages` instead.
         If true, the counts are assumed to be percentages and % marks will be added to the x-axis labels.
-        If both `plot_percentage` and `counts_are_percentages` are specified, the former overrides the latter.
     colors : list of str
         A list of colors in hex string or RGB tuples to use for plotting.
         Attention: if your colormap doesn't work right try appending transparent ("#ffffff00") in the first place.
@@ -76,9 +73,6 @@ def plot_counts(
         Controls the interval between x-axis ticks.
     compute_percentages: bool = False,
         Convert the given response counts to percentages and display the counts as percentages in the plot.
-    counts_are_percentages: bool = False,
-        If true, the counts are assumed to be percentages and % marks will be added to the x-axis labels.
-        If `compute_percentages` is True, this parameter is ignored.
 
     Returns
     -------
@@ -91,15 +85,17 @@ def plot_counts(
     """
     if plot_percentage is not None:
         warn(
-            "parameter `plot_percentage` for `plot_likert.likert_counts` is deprecated, use `counts_are_percentages` instead",
+            "parameter `plot_percentage` for `plot_likert.likert_counts` is deprecated, set it to None and use `compute_percentages` instead",
             FutureWarning,
         )
         counts_are_percentages = plot_percentage
-
-    # Re-compute counts as percentages, if requested
-    if compute_percentages:
-        counts = _compute_counts_percentage(counts)
-        counts_are_percentages = True
+    else:
+        # Re-compute counts as percentages, if requested
+        if compute_percentages:
+            counts = _compute_counts_percentage(counts)
+            counts_are_percentages = True
+        else:
+            counts_are_percentages = False
 
     # Pad each row/question from the left, so that they're centered around the middle (Neutral) response
     scale_middle = len(scale) // 2

--- a/plot_likert/plot_likert.py
+++ b/plot_likert/plot_likert.py
@@ -289,12 +289,12 @@ def plot_likert(
         plot_scale = plot_scale[1:]
 
     return plot_counts(
-        counts,
-        plot_scale,
-        plot_percentage,
-        colors,
+        counts=counts,
+        scale=plot_scale,
+        colors=colors,
         figsize=figsize,
         xtick_interval=xtick_interval,
+        counts_are_percentages=plot_percentage,
     )
 
 

--- a/plot_likert/plot_likert.py
+++ b/plot_likert/plot_likert.py
@@ -48,6 +48,7 @@ def plot_counts(
     colors: colors.Colors = colors.default,
     figsize=None,
     xtick_interval: typing.Optional[int] = None,
+    compute_percentages: bool = False,
     counts_are_percentages: bool = False,
 ) -> matplotlib.axes.Axes:
     """
@@ -73,8 +74,11 @@ def plot_counts(
         A tuple (width, heigth) that controls size of the final figure - similarly to matplotlib
     xtick_interval : int, optional
         Controls the interval between x-axis ticks.
+    compute_percentages: bool = False,
+        Convert the given response counts to percentages and display the counts as percentages in the plot.
     counts_are_percentages: bool = False,
         If true, the counts are assumed to be percentages and % marks will be added to the x-axis labels.
+        If `compute_percentages` is True, this parameter is ignored.
 
     Returns
     -------
@@ -91,6 +95,11 @@ def plot_counts(
             FutureWarning,
         )
         counts_are_percentages = plot_percentage
+
+    # Re-compute counts as percentages, if requested
+    if compute_percentages:
+        counts = counts.divide(counts.sum(axis="columns"), axis="rows") * 100.0
+        counts_are_percentages = True
 
     # Pad each row/question from the left, so that they're centered around the middle (Neutral) response
     scale_middle = len(scale) // 2


### PR DESCRIPTION
Issue #17 pointed out an awkwardness in the behavior of the `plot_counts` function:

> When using plot_count to plot a graph, plot_percentages seemed to only just add a percentage sign on to the end of the number of respondents rather than convert the number of responses to percentages.

As I wrote at the time:

> the reason this behavior exists is because plot_counts is honestly mostly an internal method […]
> That said, since `plot_counts` _is_ being exposed, I agree that its behavior is confusing and unexpected, so I think the change you're proposing [computing percentages] makes sense.

To address this issue, the commits that are part of this PR make the following changes to the `plot_counts` function:

1. Deprecate the `plot_percentage` parameter with a warning (but keep it around for backwards compatibility)
2. Add new parameter `compute_percentages` that converts the count to percentages


**Note that these changes only affect `plot_counts`.** `plot_likert.plot_likert`, which is the primary entry point of this library, has not changed.
